### PR TITLE
Fix file extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ After the adder runs,
 
 - You can use Tailwind utility classes like `bg-blue-700` in the markup (components, routes, `app.html`).
 
-- You can use [Tailwind directives like `@apply` and `@screen` or use the `theme` function](https://tailwindcss.com/docs/functions-and-directives) in Svelte `style lang="postcss"` blocks or the `src/app.postcss` file.
+- You can use [Tailwind directives like `@apply` and `@screen` or use the `theme` function](https://tailwindcss.com/docs/functions-and-directives) in Svelte `style lang="postcss"` blocks or the `src/app.css` file.
 
 - You can [configure Tailwind](https://tailwindcss.com/docs/configuration) in the `tailwind.config.cjs` file.
 


### PR DESCRIPTION
I don't see any file named `app.postcss`, so I'm wondering if it should be `app.css`?