### PR TITLE
add options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ This adder supports SvelteKit and Vite-powered Svelte apps (all the environments
 
 - `typography` (default `false`): whether or not to install and set up the [Tailwind CSS Typography plugin](https://github.com/tailwindlabs/tailwindcss-typography).
 
+Options can be used like so:
+```sh 
+npx svelte-add@latest tailwindcss --forms --typography
+```
+
 ## 🛠 Using Tailwind CSS
 
 After the adder runs,


### PR DESCRIPTION
Wasn't clear exactly how to add options flag, even in the svelte-add readme. I had to mess with a couple flag options before realizing is was 2 dashes. 😅

So I just added a little example at the bottom of the options section!