### PR TITLE
🐛 fix: #318 Tailwindcss prettier config should accomodate other plugins

### DIFF
--- a/__info.js
+++ b/__info.js
@@ -80,16 +80,14 @@ export const heuristics = [
 
 			// check plugins
 			const tailwindPlugin = "prettier-plugin-tailwindcss" in folderInfo.allDependencies;
-			const sveltePlugin = "prettier-plugin-svelte" in folderInfo.allDependencies;
-			if (!tailwindPlugin || sveltePlugin) return false;
+			if (!tailwindPlugin) return false;
 
-			// prettier-plugin-tailwindcss should replace prettier-plugin-svelte in .prettierrc
 			const prettierConfig = await readFile({ path: prettierConfigPath });
 			if (!prettierConfig) return false;
 
 			const { text } = prettierConfig;
 			const { plugins } = JSON.parse(text);
-			return plugins.includes("prettier-plugin-tailwindcss") && !plugins.includes("prettier-plugin-svelte");
+			return plugins.includes("prettier-plugin-tailwindcss");
 		},
 	},
 ];

--- a/__run.js
+++ b/__run.js
@@ -326,17 +326,7 @@ export const run = async ({ install, options, updateCss, updateJavaScript, updat
 		await updateJson({
 			path: prettierConfigPath,
 			async json({ obj }) {
-				const plugins = obj.plugins.filter((/** @type {string} */ plugin) => plugin !== "prettier-plugin-svelte");
-				obj.plugins = ["prettier-plugin-tailwindcss", ...plugins];
-				return { obj };
-			},
-		});
-
-		// update package.json
-		await updateJson({
-			path: "/package.json",
-			async json({ obj }) {
-				delete obj.devDependencies["prettier-plugin-svelte"];
+				obj.plugins = obj.plugins ? [...obj.plugins, "prettier-plugin-tailwindcss"] : ["prettier-plugin-tailwindcss"];
 				return { obj };
 			},
 		});


### PR DESCRIPTION
This PR is in relation to its parent https://github.com/svelte-add/svelte-add/pull/322 and is in response to #318